### PR TITLE
Adjust Documentation, Add --version, Fix E-Mail Link Bug

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,7 @@ src/pymarktools/
 ### Changelog
 
 - When adding, changing, or removing features, update the `CHANGELOG.md` file with a clear description of the change, the reason for it, and any relevant context.
-- Use the format: `## [version] - [date]` (e.g., `## [0.1.1] - 2025-07-08`).
+- Use the format: `## [version] - [date]` (e.g., `## [0.2.0] - 2025-07-08`).
     - Separate changes into sections: `Added`, `Changed`, `Removed`, `Fixed`, etc.
 - For unreleased changes, use `[unreleased]` as the version and date.
 - Follow the existing changelog structure for consistency.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,15 @@
-# pymarktools AI Agent Instructions
-
 ## Project Overview
 
-pymarktools is a Python-based markdown utility library designed to help with markdown file manipulation, validation, and refactoring. It focuses on link and image handling, with features for checking validity and fixing common issues.
+pymarktools is a Python library for markdown file manipulation: validation, refactoring, and link/image handling.
 
-## Core Assumptions
+## Style Guide
 
-- Target python version is 3.13
+- Target Python 3.13 with type hints on all public APIs.
+- Use NumPy-style docstrings (no inline type hints).
+- Follow `snake_case` for functions and variables; `PascalCase` for classes.
+- Organize imports in three groups: standard library, third-party, local modules.
+- Enforce linting and formatting with Ruff and ty.
+- Write tests in `tests/` mirroring the source structure; use pytest and mock external calls.
 - The library is intended for use in both CLI and programmatic contexts
 - Properly document all public APIs and provide type hints for all functions
 - Use `uv` for managing the virtual environment and running commands
@@ -17,266 +20,62 @@ The project follows a modular structure:
 
 ```
 src/pymarktools/
-├── __init__.py         # Public API exports
-├── cli.py              # Main CLI app entry point with global options
-├── state.py            # Global state management for CLI options
-├── commands/           # CLI command implementations
-│   ├── check.py        # Link/image validation commands with callback architecture
-│   └── refactor.py     # File movement and reference updating
-└── core/               # Core business logic
-    ├── models.py       # Data classes (LinkInfo, ImageInfo)
-    ├── link_checker.py # Link validation with pattern filtering support
-    ├── image_checker.py# Image validation with pattern filtering support
-    ├── gitignore.py    # Git repository and .gitignore handling
-    ├── markdown.py     # Re-exports for backward compatibility
-    └── refactor.py     # Markdown reference refactoring logic
+├── __init__.py          # Public API exports
+├── cli.py               # Main CLI app entry point with global options
+├── state.py             # Global state management for CLI options
+├── commands/            # CLI command implementations
+│   ├── __init__.py      # Commands module exports
+│   ├── check.py         # Link/image validation commands with callback architecture
+│   └── refactor.py      # File movement and reference updating
+└── core/                # Core business logic
+    ├── __init__.py      # Core module exports
+    ├── async_checker.py # Base async checker functionality
+    ├── gitignore.py     # Git repository and .gitignore handling
+    ├── image_checker.py # Image validation with pattern filtering support
+    ├── link_checker.py  # Link validation with pattern filtering support
+    ├── markdown.py      # Re-exports for backward compatibility
+    ├── models.py        # Data classes (LinkInfo, ImageInfo)
+    └── refactor.py      # Markdown reference refactoring logic
 
 ```
 
-### Core Components
+## Workflow Guidelines
 
-1. **Data Classes** (in `core/models.py`)
+### CLI Usage
 
-    - `LinkInfo`: Store structured data about markdown links with validation status
-    - `ImageInfo`: Store structured data about markdown images with validation status
-    - Both support local file checking with `is_local` and `local_path` fields for debugging/display
-    - `FileReference`: Represents file references in markdown (in refactor.py)
+- Use `uv` for virtual environment and commands: `uv install`, `uv run`, especially `uv run python`.
+- Commands follow Typer patterns with shared options in `state.py`.
+- Common flags:
+    - `--check-external`, `--check-local`, `--fix-redirects`
+    - `--include`, `--exclude`, `--parallel`, `--workers`
+    - `--quiet` (errors only), `--verbose` (detailed output), default (status + summary)
 
-1. **Core Services**
+### Async Processing
 
-    - `DeadLinkChecker` (in `core/link_checker.py`): Validates and fixes links in markdown files with pattern filtering and parallel processing
-    - `DeadImageChecker` (in `core/image_checker.py`): Validates and fixes image references in markdown with pattern filtering and parallel processing
-    - `FileReferenceManager` (in `core/refactor.py`): Handles refactoring file references during moves
-    - Gitignore support (in `core/gitignore.py`): Respects .gitignore patterns when scanning directories
+- External URL checks use `httpx.AsyncClient` without redirects.
+- Use `asyncio.gather()` and semaphores for concurrency.
+- Local file checks are synchronous via `pathlib.Path`.
 
-1. **CLI Interface**
+### Refactoring
 
-    - Uses Typer for command definition with callback architecture for shared options
-    - Global state management via `state.py` for verbose/quiet/color modes
-    - Commands are grouped by functionality (check, refactor)
-    - Supports flexible option placement: options can be specified at callback or individual command level
-    - Individual command options override callback options when provided
-    - Comprehensive options: `--check-external`, `--check-local`, `--fix-redirects`, `--follow-gitignore`, `--include`, `--exclude`, `--parallel`, `--workers`, `--color`
-    - Exit code behavior: returns 0 for success, 1 for validation failures (suitable for CI/CD)
+- File moves update markdown references using `FileReferenceManager`.
+- Respect `.gitignore` patterns by default; override with `--no-follow-gitignore`.
 
-1. **Async Processing**
+### Color Output
 
-    - AsyncIO-based concurrent execution for external URL validation
-    - Configurable worker limit with `--workers` option (defaults to CPU cores)
-    - Enable/disable with `--parallel`/`--no-parallel` flags
-    - Automatic separation of external (async) and local (sequential) validation
-    - Significant performance improvements for network-bound operations with better resource utilization
+- Use automated color detection; fallback to plain text.
+- Status indicators:
+    - ✓ valid
+    - ✗ broken
+    - ⚠ warnings
 
-1. **Color Output System**
+### Changelog
 
-    - Typer.secho()-based colored terminal output with visual status indicators
-    - Global `--color`/`--no-color` options for consistent styling
-    - Helper functions for standardized color coding across commands
-    - Automatic color detection and fallback for non-terminal environments
-    - Status-based coloring: green for success, red for errors, yellow for warnings, blue for info
-
-1. **Global State Management** (in `state.py`)
-
-    - Centralized state management to avoid circular imports
-    - Supports verbose, quiet, and color modes across all commands
-    - Shared between CLI entry point and command modules
-
-## Key Workflows
-
-### 1. CLI Option Architecture
-
-The CLI supports flexible option placement with callback architecture:
-
-- **Callback Options**: Common options can be specified at the check command level
-- **Individual Command Options**: All options are also available on individual commands
-- **Option Precedence**: Command-specific options override callback options when provided
-- **Global Options**: `--verbose` and `--quiet` are available at the main CLI level
-
-```bash
-# Options at callback level (apply to all check subcommands)
-uv run pymarktools check --timeout 60 --no-check-external dead-links file.md
-
-# Options at command level (override callback settings)  
-uv run pymarktools check dead-links file.md --timeout 30 --check-external
-
-# Mixed approach (command overrides callback when both specified)
-uv run pymarktools check --include "*.md" dead-links --timeout 60 file.md
-```
-
-### 2. Verbosity Levels
-
-The system supports three verbosity levels controlled by global options:
-
-| Level       | Flag        | Description                 | Output Includes                                                                                                                               |
-| ----------- | ----------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Quiet**   | `--quiet`   | Minimal output, errors only | Critical errors, final summary counts                                                                                                         |
-| **Default** | _(none)_    | Standard output level       | File processing status, broken link/image reports, summary statistics                                                                         |
-| **Verbose** | `--verbose` | Detailed diagnostic output  | All default output plus individual validation results, HTTP response codes, redirect chains, file path resolution details, performance timing |
-
-```bash
-# Quiet mode - minimal output
-uv run pymarktools --quiet check dead-links docs/
-
-# Default mode - standard output  
-uv run pymarktools check dead-links docs/
-
-# Verbose mode - detailed diagnostics
-uv run pymarktools --verbose check dead-links docs/
-```
-
-### 3. Async Processing
-
-The system uses asyncio for concurrent external URL validation:
-
-```bash
-# Use async processing with default worker count (CPU cores)
-uv run pymarktools check dead-links docs/ --parallel
-
-# Customize the number of concurrent workers
-uv run pymarktools check dead-links docs/ --workers 8
-
-# Disable async processing for sequential operation
-uv run pymarktools check dead-links docs/ --no-parallel
-```
-
-Async processing automatically separates:
-
-- **External URLs**: Checked asynchronously using asyncio.gather() and semaphores for network I/O efficiency
-- **Local files**: Checked sequentially as they are typically fast file system operations
-
-### 4. Color Output
-
-Visual status indicators enhance terminal output:
-
-```bash
-# Enable colored output (default in terminals)
-uv run pymarktools --color check dead-links docs/
-
-# Disable colored output for plain text
-uv run pymarktools --no-color check dead-links docs/
-```
-
-Color coding provides instant visual feedback:
-
-- **Green (✓)**: Valid links/images
-- **Red (✗)**: Broken or invalid references
-- **Yellow**: Warnings and redirects
-- **Blue**: Informational messages
-
-Colors automatically disable in non-terminal environments or when output is redirected.
-
-### 5. Link/Image Validation
-
-The primary workflow is checking markdown files for dead links or images:
-
-```python
-# Create a checker with all validation options
-checker = DeadLinkChecker(
-    timeout=30, 
-    check_external=True, 
-    check_local=True,
-    fix_redirects=True,
-    follow_gitignore=True,
-    parallel=True,
-    workers=8
-)
-
-# Check a single file (uses async internally)
-links = checker.check_file(path)
-
-# Or check an entire directory with pattern filtering (uses async internally)
-results = checker.check_directory(
-    directory, 
-    include_pattern="*.md", 
-    exclude_pattern="draft_*"
-)
-
-# For async usage (advanced)
-links = await checker.check_file_async(path)
-results = await checker.check_directory_async(directory, "*.md")
-```
-
-```
-follow_gitignore=True
-```
-
-)
-
-# Check a single file
-
-links = checker.check_file(path)
-
-# Or check an entire directory with pattern filtering
-
-results = checker.check_directory(
-directory,
-include_pattern="*.md",
-exclude_pattern="draft\_*"
-)
-
-````
-
-The same pattern applies to `DeadImageChecker`. Both checkers support:
-- **External URL validation**: HTTP/HTTPS links with redirect handling
-- **Local file validation**: Relative and absolute file path checking with proper path resolution
-- **Gitignore integration**: Automatically skip ignored files and directories
-- **Pattern filtering**: Include/exclude patterns using fnmatch for flexible file selection
-
-### 6. File Refactoring
-
-To move files and update all references:
-
-```python
-# Create a manager
-manager = FileReferenceManager(base_dir=repo_root)
-
-# Find references to a file
-refs = manager.find_references(target_file, include_pattern="*.md")
-
-# Move file and update references
-manager.move_file_and_update_references(source, destination, refs)
-````
-
-### 7. Gitignore Integration
-
-The system automatically respects .gitignore patterns:
-
-- Searches for .gitignore files from current directory up to repository root
-- Uses `gitignore_parser` library for spec-compliant pattern matching
-- Supports hierarchical .gitignore files in subdirectories
-- Can be disabled with `--no-follow-gitignore` option
-
-## Development Conventions
-
-### HTTP Handling
-
-- External links are checked using `httpx.AsyncClient` with configurable timeouts for async operation
-- HTTP requests use `follow_redirects=False` to detect and handle redirects manually
-- Permanent redirects (301, 307, 308) can be automatically fixed with `fix_redirects=True`
-- Async processing uses `asyncio.gather()` with semaphores for rate limiting and resource management
-
-### Local File Handling
-
-- Local file paths are validated using `pathlib.Path` for cross-platform compatibility
-- Relative paths are resolved from the markdown file's directory
-- Absolute paths are resolved from the markdown file's parent directory
-- Anchors and query parameters are stripped for file existence checking
-- Path normalization handles `..` and `.` components correctly
-- Enhanced data models include `is_local` and `local_path` fields for debugging
-
-### Markdown Processing
-
-- Regex patterns extract links and images: `\[([^\]]*)\]\(([^)]+)\)` for links and `!\[([^\]]*)\]\(([^)]+)\)` for images
-- Images are excluded from link extraction to avoid double-processing
-- String replacement is used for content updates (rather than regex replacement) to avoid escaping issues
-- File paths are handled via Python's `pathlib.Path` throughout the codebase
-
-### Gitignore Support
-
-- Uses `gitignore_parser` library for spec-compliant .gitignore parsing
-- Recursively discovers .gitignore files from target directory up to repository root
-- Combines patterns from all .gitignore files in the hierarchy
-- Repository root is detected by finding the `.git` directory
+- When adding, changing, or removing features, update the `CHANGELOG.md` file with a clear description of the change, the reason for it, and any relevant context.
+- Use the format: `## [version] - [date]` (e.g., `## [0.1.1] - 2025-07-08`).
+    - Separate changes into sections: `Added`, `Changed`, `Removed`, `Fixed`, etc.
+- For unreleased changes, use `[unreleased]` as the version and date.
+- Follow the existing changelog structure for consistency.
 
 ### Testing
 
@@ -304,6 +103,7 @@ The system automatically respects .gitignore patterns:
 1. Write comprehensive tests in `tests/test_core/`
 1. Export public APIs through `__init__.py`
 1. Update type hints and documentation
+1. Update the changelog
 
 ## Testing and Running
 
@@ -337,7 +137,7 @@ uv run pytest --cov=src/pymarktools
 
 ```
 
-### Runnin Quality Checks
+### Running Quality Checks
 
 #### Typechecker
 
@@ -351,48 +151,3 @@ uv run ty check
 uv run ruff check src/pymarktools tests --fix
 uv run ruff format --check src/pymarktools tests
 ```
-
-### CLI Usage
-
-```bash
-# Check for dead links with global verbose mode
-uv run pymarktools --verbose check dead-links README.md --check-external --fix-redirects
-
-# Check for dead images with command-specific options
-uv run pymarktools check dead-images docs/ --timeout 60 --include "*.md" --exclude "draft_*"
-
-# Check only local files, skip external URLs
-uv run pymarktools check dead-links docs/ --no-check-external
-
-# Skip local file checking, only check external URLs  
-uv run pymarktools check dead-links docs/ --no-check-local
-
-# Disable gitignore filtering
-uv run pymarktools check dead-links docs/ --no-follow-gitignore
-
-# Use parallel processing with custom worker count
-uv run pymarktools check dead-links docs/ --parallel --workers 8
-
-# Disable parallel processing
-uv run pymarktools check dead-links docs/ --no-parallel
-
-# Enable color output
-uv run pymarktools --color check dead-links docs/
-
-# Disable color output
-uv run pymarktools --no-color check dead-links docs/
-
-# Mix callback and command options (command options override callback)
-uv run pymarktools check --timeout 30 dead-links file.md --timeout 10
-
-# Move a file and update references with pattern filtering
-uv run pymarktools refactor move old/path.md new/path.md --include "*.md"
-```
-
-### Async Implementation
-
-- Core URL checking uses `async`/`await` patterns with `httpx.AsyncClient` for non-blocking HTTP requests
-- `asyncio.gather()` coordinates concurrent execution with configurable semaphores for rate limiting
-- Automatic fallback to synchronous execution when methods are overridden (for test compatibility)
-- Event loop detection prevents `asyncio.run()` conflicts in async contexts (CLI testing)
-- Uses ThreadPoolExecutor as fallback when already in async context to avoid event loop nesting issues

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    "recommendations": [
+        "teticio.python-envy",
+        "astral-sh.ty",
+        "charliermarsh.ruff",
+        "github.vscode-github-actions",
+        "github.vscode-pull-request-github",
+        "gruntfuggly.todo-tree",
+        "vscode-icons-team.vscode-icons",
+        "tamasfe.even-better-toml"
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Pymarktools Changelog
+
+## [0.1.1] - 2025-07-08
+
+### [0.1.1] - Added
+
+- Global `--version` option to the CLI, allowing users to display the current pymarktools version and exit. Implements Typer's recommended approach for version callbacks.
+- Added this changelog
+- Added `.vscode` extension recommendations
+
+### [0.1.1] - Changed
+
+- Adjusted Readme for more clarity
+- Adjusted Project description and metadata for pypi
+
+## [0.1.0] - 2025-07-08
+
+### [0.1.0] - Added
+
+- Initial release of pymarktools.
+- CLI for markdown link and image validation.
+- Async processing for external URL checks with configurable workers.
+- Gitignore support for directory scanning.
+- File refactoring with reference updating.
+- Comprehensive test suite and CI/CD integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,24 @@
 # Pymarktools Changelog
 
-## [0.1.1] - 2025-07-08
+## [0.2.0] - 2025-07-08
 
-### [0.1.1] - Added
+### [0.2.0] - Added
 
-- Global `--version` option to the CLI, allowing users to display the current pymarktools version and exit. Implements Typer's recommended approach for version callbacks.
+- Global `--version` option to the CLI, allowing users to display the current pymarktools version and exit. Implements
+    Typer's recommended approach for version callbacks.
 - Added this changelog
 - Added `.vscode` extension recommendations
 
-### [0.1.1] - Changed
+### [0.2.0] - Changed
 
 - Adjusted Readme for more clarity
 - Adjusted Project description and metadata for pypi
+
+### [0.2.0] - Fixed
+
+- Fixed bug where email links with `mailto:` scheme were incorrectly treated as local file paths instead of external
+    URLs. Email links are now properly recognized as external and validated by checking domain existence rather than
+    being flagged as missing local files.
 
 ## [0.1.0] - 2025-07-08
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+pyproject.toml @jancschaefer
+.github @jancschaefer

--- a/README.md
+++ b/README.md
@@ -381,3 +381,7 @@ uv run ruff format --check src/pymarktools tests
 ## License
 
 This project is licensed under the MIT License. See the LICENSE file for more details.
+
+## Test
+
+[email](mailto:email@domain.com)

--- a/README.md
+++ b/README.md
@@ -381,7 +381,3 @@ uv run ruff format --check src/pymarktools tests
 ## License
 
 This project is licensed under the MIT License. See the LICENSE file for more details.
-
-## Test
-
-[email](mailto:email@domain.com)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,10 @@
 # Release Process for pymarktools
 
+![](https://badgen.net/github/license/jancschaefer/pymarktools)
+![](https://badgen.net/github/tag/jancschaefer/pymarktools)
+![](https://badgen.net/github/release/jancschaefer/pymarktools)
+![](https://badgen.net/github/checks/jancschaefer/pymarktools/main)
+
 This document outlines the release process for the pymarktools package.
 
 ## Overview
@@ -32,6 +37,12 @@ Production releases to PyPI happen when you create a GitHub release.
 ## Step-by-Step Release Process
 
 ### Step 1: Prepare the Release
+
+
+1. **Update the changelog** in `CHANGELOG.md`:
+
+    - Add a new section for the release version and date
+    - Summarize all user-facing changes, fixes, and improvements
 
 1. **Update the version** in `pyproject.toml`:
 
@@ -202,7 +213,6 @@ Use this checklist for each release:
 - [ ] Automated workflows completed successfully
 - [ ] Package available on PyPI
 - [ ] Installation and basic functionality tested
-- [ ] Release announcement (if applicable)
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -164,7 +164,7 @@ If a release needs to be rolled back:
 1. **Fix and re-release**:
 
     - Fix the issue in code
-    - Bump the version (e.g., 0.2.0 → 0.1.2)
+    - Bump the version (e.g., 0.2.0 → 0.2.1) in `pyproject.toml` and `src/pymarktools/__init__.py`
     - Follow the normal release process
 
 ## Troubleshooting

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,7 +49,7 @@ Production releases to PyPI happen when you create a GitHub release.
     ```toml
     [project]
     name = "pymarktools"
-    version = "0.1.1"  # Update this
+    version = "0.2.0"  # Update this
     ```
 
 1. **Update documentation** if needed (README.md, CHANGELOG.md, etc.)
@@ -58,7 +58,7 @@ Production releases to PyPI happen when you create a GitHub release.
 
     ```bash
     git add pyproject.toml
-    git commit -m "chore: bump version to 0.1.1"
+    git commit -m "chore: bump version to 0.2.0"
     git push origin main
     ```
 
@@ -68,17 +68,17 @@ Production releases to PyPI happen when you create a GitHub release.
 
 ```bash
 # Create a tag (must match the version in pyproject.toml)
-git tag v0.1.1
+git tag v0.2.0
 
 # Push the tag to trigger the release workflow
-git push origin v0.1.1
+git push origin v0.2.0
 ```
 
 ### Step 3: Create a GitHub Release
 
 1. Go to [GitHub Releases](https://github.com/jancschaefer/pymarktools/releases)
 1. Click "Create a new release"
-1. Select the tag you just created (`v0.1.1`)
+1. Select the tag you just created (`v0.2.0`)
 1. Fill in the release title and description
 1. Click "Publish release"
 
@@ -123,7 +123,7 @@ Follow [Semantic Versioning](https://semver.org/):
 Examples:
 
 - `0.1.0` - Initial release
-- `0.1.1` - Patch release (bug fixes)
+- `0.2.0` - Patch release (bug fixes)
 - `0.2.0` - Minor release (new features, backward compatible)
 - `1.0.0` - Major release (breaking changes)
 - `1.0.0a1` - Alpha pre-release
@@ -164,7 +164,7 @@ If a release needs to be rolled back:
 1. **Fix and re-release**:
 
     - Fix the issue in code
-    - Bump the version (e.g., 0.1.1 → 0.1.2)
+    - Bump the version (e.g., 0.2.0 → 0.1.2)
     - Follow the normal release process
 
 ## Troubleshooting

--- a/cli-test.sh
+++ b/cli-test.sh
@@ -109,6 +109,7 @@ echo -e "${BLUE}=== Testing Basic Usage ===${NC}"
 run_test "Basic help" "uv run pymarktools --help"
 run_test "Verbose mode" "uv run pymarktools --verbose check dead-links $temp_dir/sample.md"
 run_test "Quiet mode" "uv run pymarktools --quiet check dead-images $temp_dir/"
+run_test "Version" "uv run pymarktools --version"
 
 # Section: Check for Dead Links and Images
 echo -e "${BLUE}=== Testing Dead Links and Images ===${NC}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pymarktools"
-version = "0.1.1"
+version = "0.2.0"
 description = "A set of markdown utilities for Python, designed to simplify the manipulation and parsing of markdown text. This project leverages Typer for a user-friendly command line interface and is built with a solid codebase structure to facilitate easy development and testing."
 authors = [
     {name = 'Jan Schäfer', email = 'jan@schae.fr'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,24 @@
 [project]
 name = "pymarktools"
-version = "0.1.0"
-description = "Add your description here"
+version = "0.1.1"
+description = "A set of markdown utilities for Python, designed to simplify the manipulation and parsing of markdown text. This project leverages Typer for a user-friendly command line interface and is built with a solid codebase structure to facilitate easy development and testing."
 authors = [
     {name = 'Jan Schäfer', email = 'jan@schae.fr'},
 ]
 readme = "README.md"
 requires-python = ">=3.13"
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
+]
+
 dependencies = [
     "gitignore-parser>=0.1.12",
     "httpx>=0.28.1",
@@ -15,6 +27,13 @@ dependencies = [
 scripts = { pymarktools = "pymarktools.cli:app", pymd = "pymarktools.cli:app" }
 license ="MIT"
 license-files = ["LICENSE"]
+
+[project.urls]
+Homepage = "https://github.com/jancschaefer/pymarktools"
+Documentation = "https://github.com/jancschaefer/pymarktools/blob/main/README.md"
+Repository = "https://github.com/jancschaefer/pymarktools"
+Issues = "https://github.com/jancschaefer/pymarktools/issues"
+Changelog = "https://github.com/jancschaefer/pymarktools/blob/main/CHANGELOG.md"
 
 [tool.pytest.ini_options]
 minversion = "8.0"
@@ -38,6 +57,7 @@ markers = [
     "unit: marks tests as unit tests",
     "integration: marks tests as integration tests",
 ]
+
 
 [build-system]
 requires = ["hatchling"]

--- a/src/pymarktools/__init__.py
+++ b/src/pymarktools/__init__.py
@@ -5,7 +5,7 @@ import logging
 from .core.markdown import DeadImageChecker, DeadLinkChecker, ImageInfo, LinkInfo
 from .core.refactor import FileReference, FileReferenceManager
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 __all__ = [
     "DeadLinkChecker",
     "DeadImageChecker",

--- a/src/pymarktools/__init__.py
+++ b/src/pymarktools/__init__.py
@@ -5,7 +5,7 @@ import logging
 from .core.markdown import DeadImageChecker, DeadLinkChecker, ImageInfo, LinkInfo
 from .core.refactor import FileReference, FileReferenceManager
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __all__ = [
     "DeadLinkChecker",
     "DeadImageChecker",
@@ -17,7 +17,4 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-
-def greet():
-    """Welcome message for pymarktools."""
-    logger.info("Welcome to pymarktools - your set of markdown utilities for Python!")
+logger.debug("pymarktools initialized with version %s", __version__)

--- a/src/pymarktools/cli.py
+++ b/src/pymarktools/cli.py
@@ -4,6 +4,8 @@ import os
 
 import typer
 
+from . import __version__
+
 # Import the command modules
 from .commands import check_app, refactor_app
 from .state import global_state
@@ -13,6 +15,8 @@ app: typer.Typer = typer.Typer(
     name="pymarktools",
     help="A set of markdown utilities for Python",
     no_args_is_help=True,
+    add_completion=True,
+    pretty_exceptions_enable=True,
 )
 
 
@@ -21,9 +25,16 @@ def main(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
     quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress non-essential output"),
     color: bool = typer.Option(True, "--color/--no-color", help="Enable colorized output"),
+    version: bool = typer.Option(
+        None,
+        "--version",
+        callback=lambda value: (typer.echo(__version__) or raise_(typer.Exit())) if value else None,
+        is_eager=True,
+        help="Show the version and exit.",
+        show_default=False,
+    ),
 ) -> None:
     """A set of markdown utilities for Python.
-
     Tools for checking links, images, and refactoring markdown files.
     Supports local file validation, external URL checking, and gitignore integration.
     """
@@ -56,6 +67,12 @@ def main(
         typer.echo("Verbose mode enabled")
     elif quiet:
         typer.echo("Quiet mode enabled", err=True)
+
+
+# Helper to raise exceptions in lambda
+def raise_(ex):
+    """Raise the given exception. Used for control flow in Typer option callbacks."""
+    raise ex
 
 
 # Add the subcommands

--- a/src/pymarktools/core/async_checker.py
+++ b/src/pymarktools/core/async_checker.py
@@ -229,14 +229,14 @@ class AsyncChecker(Generic[T]):
         """Check if URL is external (has a scheme)."""
         # Common external URL schemes
         external_schemes = (
-            "ftp://",      # File transfer
-            "ftps://",     # Secure File transfer
-            "http://",     # Web
-            "https://",    # Secure Web
-            "mailto:",     # Email
-            "sftp://",     # Secure shell/file transfer
-            "sms:",        # Telephone/SMS
-            "ssh://",      # Secure shell
-            "tel:",        # Telephone
+            "ftp://",  # File transfer
+            "ftps://",  # Secure File transfer
+            "http://",  # Web
+            "https://",  # Secure Web
+            "mailto:",  # Email
+            "sftp://",  # Secure shell/file transfer
+            "sms:",  # Telephone/SMS
+            "ssh://",  # Secure shell
+            "tel:",  # Telephone
         )
         return url.startswith(external_schemes)

--- a/src/pymarktools/core/async_checker.py
+++ b/src/pymarktools/core/async_checker.py
@@ -224,3 +224,19 @@ class AsyncChecker(Generic[T]):
                     results[item] = None
 
         return results
+
+    def is_external_url(self, url: str) -> bool:
+        """Check if URL is external (has a scheme)."""
+        # Common external URL schemes
+        external_schemes = (
+            "ftp://",      # File transfer
+            "ftps://",     # Secure File transfer
+            "http://",     # Web
+            "https://",    # Secure Web
+            "mailto:",     # Email
+            "sftp://",     # Secure shell/file transfer
+            "sms:",        # Telephone/SMS
+            "ssh://",      # Secure shell
+            "tel:",        # Telephone
+        )
+        return url.startswith(external_schemes)

--- a/src/pymarktools/core/image_checker.py
+++ b/src/pymarktools/core/image_checker.py
@@ -50,8 +50,18 @@ class DeadImageChecker(AsyncChecker[ImageInfo]):
         return images
 
     def is_external_url(self, url: str) -> bool:
-        """Check if URL is external (http/https)."""
-        return url.startswith(("http://", "https://"))
+        """Check if URL is external (has a scheme)."""
+        # Common external URL schemes
+        external_schemes = (
+            "http://",
+            "https://",  # Web
+            "ftp://",
+            "ftps://",  # File transfer
+            "ssh://",
+            "sftp://",  # Secure shell/file transfer
+            "file://",  # File URLs (often external references)
+        )
+        return url.startswith(external_schemes)
 
     def check_local_path(self, url: str, base_path: Path) -> dict[str, Any]:
         """Check if a local file path exists relative to the base path."""

--- a/src/pymarktools/core/image_checker.py
+++ b/src/pymarktools/core/image_checker.py
@@ -49,20 +49,6 @@ class DeadImageChecker(AsyncChecker[ImageInfo]):
 
         return images
 
-    def is_external_url(self, url: str) -> bool:
-        """Check if URL is external (has a scheme)."""
-        # Common external URL schemes
-        external_schemes = (
-            "http://",
-            "https://",  # Web
-            "ftp://",
-            "ftps://",  # File transfer
-            "ssh://",
-            "sftp://",  # Secure shell/file transfer
-            "file://",  # File URLs (often external references)
-        )
-        return url.startswith(external_schemes)
-
     def check_local_path(self, url: str, base_path: Path) -> dict[str, Any]:
         """Check if a local file path exists relative to the base path."""
         result: dict[str, Any] = {

--- a/src/pymarktools/core/link_checker.py
+++ b/src/pymarktools/core/link_checker.py
@@ -57,8 +57,79 @@ class DeadLinkChecker(AsyncChecker[LinkInfo]):
         return links
 
     def is_external_url(self, url: str) -> bool:
-        """Check if URL is external (http/https)."""
-        return url.startswith(("http://", "https://"))
+        """Check if URL is external (has a scheme)."""
+        # Common external URL schemes
+        external_schemes = (
+            "http://",
+            "https://",  # Web
+            "mailto:",  # Email
+            "ftp://",
+            "ftps://",  # File transfer
+            "ssh://",
+            "sftp://",  # Secure shell/file transfer
+            "tel:",
+            "sms:",  # Telephone/SMS
+            "file://",  # File URLs (often external references)
+        )
+        return url.startswith(external_schemes)
+
+    def is_email_url(self, url: str) -> bool:
+        """Check if URL is an email (mailto:) link."""
+        return url.startswith("mailto:")
+
+    def extract_email_domain(self, email_url: str) -> str:
+        """Extract domain from a mailto: URL."""
+        if not self.is_email_url(email_url):
+            raise ValueError(f"Not an email URL: {email_url}")
+
+        # Remove mailto: prefix
+        email_part = email_url[7:]  # len("mailto:") = 7
+
+        # Extract domain (part after @)
+        if "@" not in email_part:
+            raise ValueError(f"Invalid email format: {email_url}")
+
+        domain = email_part.split("@")[-1]
+
+        # Remove any query parameters or fragments
+        domain = domain.split("?")[0].split("#")[0]
+
+        return domain
+
+    async def check_email_domain_async(self, email_url: str) -> dict[str, Any]:
+        """Check if an email domain exists by validating the domain via HTTP."""
+        result: dict[str, Any] = {
+            "is_valid": False,
+            "status_code": None,
+            "error": None,
+            "redirect_url": None,
+            "is_permanent_redirect": False,
+        }
+
+        try:
+            domain = self.extract_email_domain(email_url)
+
+            # Try to validate domain existence by making a simple HTTP request
+            # This is a basic check - we're just verifying the domain resolves
+            domain_url = f"https://{domain}"
+
+            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=False) as client:
+                response: httpx.Response = await client.head(domain_url)
+                result["status_code"] = response.status_code
+
+                # For email domains, we consider any response (even 4xx/5xx) as valid
+                # since we're just checking if the domain exists, not if it serves a website
+                result["is_valid"] = True
+
+        except ValueError as e:
+            result["error"] = f"Invalid email format: {e}"
+        except httpx.RequestError as e:
+            # Network errors might indicate domain doesn't exist
+            result["error"] = f"Domain validation failed: {e}"
+        except Exception as e:
+            result["error"] = f"Email domain check failed: {e}"
+
+        return result
 
     def check_local_path(self, url: str, base_path: Path) -> dict[str, Any]:
         """Check if a local file path exists relative to the base path."""
@@ -112,6 +183,10 @@ class DeadLinkChecker(AsyncChecker[LinkInfo]):
             # Local file reference, don't check with HTTP
             result["is_valid"] = True
             return result
+
+        # Handle email URLs specially
+        if self.is_email_url(url):
+            return await self.check_email_domain_async(url)
 
         try:
             async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=False) as client:

--- a/src/pymarktools/core/link_checker.py
+++ b/src/pymarktools/core/link_checker.py
@@ -56,23 +56,6 @@ class DeadLinkChecker(AsyncChecker[LinkInfo]):
 
         return links
 
-    def is_external_url(self, url: str) -> bool:
-        """Check if URL is external (has a scheme)."""
-        # Common external URL schemes
-        external_schemes = (
-            "http://",
-            "https://",  # Web
-            "mailto:",  # Email
-            "ftp://",
-            "ftps://",  # File transfer
-            "ssh://",
-            "sftp://",  # Secure shell/file transfer
-            "tel:",
-            "sms:",  # Telephone/SMS
-            "file://",  # File URLs (often external references)
-        )
-        return url.startswith(external_schemes)
-
     def is_email_url(self, url: str) -> bool:
         """Check if URL is an email (mailto:) link."""
         return url.startswith("mailto:")

--- a/tests/test_core/test_email_integration.py
+++ b/tests/test_core/test_email_integration.py
@@ -1,0 +1,60 @@
+"""Integration test to demonstrate the email link fix."""
+
+import tempfile
+from pathlib import Path
+
+from pymarktools.core.link_checker import DeadLinkChecker
+
+
+def test_email_links_integration():
+    """Integration test showing the email link bug fix."""
+    # Create a test markdown file with various email scenarios
+    content = """# Test Document
+
+## Valid Emails
+Contact us: [Support](mailto:support@example.com)
+Sales team: [Sales](mailto:sales@github.com)
+
+## Invalid Email (for testing)
+Broken: [Bad Domain](mailto:test@nonexistentdomain98765.invalid)
+
+## Regular Links
+Website: [Example](https://example.com)
+Local file: [README](./README.md)
+"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        md_file = temp_path / "test.md"
+        md_file.write_text(content)
+
+        # Test with external checking enabled
+        checker = DeadLinkChecker(check_external=True, check_local=True)
+        links = checker.check_file(md_file)
+
+        # Verify we found all the links
+        assert len(links) == 5
+
+        # Check that email links are recognized as external
+        email_links = [link for link in links if link.url.startswith("mailto:")]
+        assert len(email_links) == 3
+
+        for email_link in email_links:
+            assert email_link.is_local is False
+            # Should have attempted validation (success or failure)
+            assert email_link.is_valid is not None
+
+        # Check that local link is still handled correctly
+        local_links = [link for link in links if not link.url.startswith(("http", "mailto:"))]
+        assert len(local_links) == 1
+        assert local_links[0].is_local is True
+        # Should be invalid since README.md doesn't exist in temp dir
+        assert local_links[0].is_valid is False
+
+        print("✅ Email links are properly recognized and validated")
+        print("✅ Local file links continue to work correctly")
+        print("✅ HTTP links continue to work correctly")
+
+
+if __name__ == "__main__":
+    test_email_links_integration()

--- a/tests/test_core/test_email_links.py
+++ b/tests/test_core/test_email_links.py
@@ -1,0 +1,152 @@
+"""Tests for email link validation."""
+
+import tempfile
+from pathlib import Path
+
+from pymarktools.core.link_checker import DeadLinkChecker
+
+
+class TestEmailLinks:
+    """Test email link validation."""
+
+    def test_extract_email_links(self):
+        """Test extracting email links from markdown content."""
+        checker = DeadLinkChecker()
+        content = """# Test Document
+
+Contact us: [email support](mailto:support@example.com)
+Send feedback to [feedback](mailto:feedback@test.org)
+Regular link: [website](https://example.com)
+"""
+
+        links = checker.extract_links(content)
+
+        assert len(links) == 3
+
+        # Check email links
+        email_links = [link for link in links if link.url.startswith("mailto:")]
+        assert len(email_links) == 2
+
+        assert email_links[0].text == "email support"
+        assert email_links[0].url == "mailto:support@example.com"
+        assert email_links[0].line_number == 3
+
+        assert email_links[1].text == "feedback"
+        assert email_links[1].url == "mailto:feedback@test.org"
+        assert email_links[1].line_number == 4
+
+    def test_is_external_url_with_email(self):
+        """Test that email URLs are recognized as external."""
+        checker = DeadLinkChecker()
+
+        # Email URLs should be external
+        assert checker.is_external_url("mailto:user@example.com") is True
+        assert checker.is_external_url("mailto:support@domain.org") is True
+
+        # HTTP/HTTPS should still work
+        assert checker.is_external_url("https://example.com") is True
+        assert checker.is_external_url("http://example.com") is True
+
+        # Local files should not be external
+        assert checker.is_external_url("./local/file.md") is False
+        assert checker.is_external_url("../other/file.md") is False
+        assert checker.is_external_url("file.md") is False
+
+    def test_is_external_url_with_other_schemes(self):
+        """Test that other common URL schemes are recognized as external."""
+        checker = DeadLinkChecker()
+
+        # Common schemes that should be external
+        assert checker.is_external_url("ftp://files.example.com") is True
+        assert checker.is_external_url("ftps://secure.example.com") is True
+        assert checker.is_external_url("ssh://server.example.com") is True
+        assert checker.is_external_url("tel:+1234567890") is True
+        assert checker.is_external_url("sms:+1234567890") is True
+
+    def test_email_domain_validation(self):
+        """Test that email URLs validate domain existence instead of full email."""
+        checker = DeadLinkChecker(check_external=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            md_file = temp_path / "test.md"
+
+            # Use a known domain for testing
+            md_file.write_text("""
+[Contact](mailto:test@example.com)
+""")
+
+            links = checker.check_file(md_file)
+
+            assert len(links) == 1
+            email_link = links[0]
+
+            # Should be recognized as external and non-local
+            assert email_link.is_local is False
+
+            # For now, let's just check that it doesn't try to validate as local file
+            # The actual domain validation will be implemented in the fix
+            assert email_link.url == "mailto:test@example.com"
+
+    def test_extract_email_domain(self):
+        """Test email domain extraction."""
+        checker = DeadLinkChecker()
+
+        # Test basic email
+        assert checker.extract_email_domain("mailto:user@example.com") == "example.com"
+
+        # Test email with query parameters
+        assert checker.extract_email_domain("mailto:user@test.org?subject=Hello") == "test.org"
+
+        # Test email with fragment
+        assert checker.extract_email_domain("mailto:user@domain.net#section") == "domain.net"
+
+        # Test complex domain
+        assert checker.extract_email_domain("mailto:contact@subdomain.example.org") == "subdomain.example.org"
+
+    def test_extract_email_domain_invalid(self):
+        """Test email domain extraction with invalid inputs."""
+        checker = DeadLinkChecker()
+
+        # Test non-email URL
+        try:
+            checker.extract_email_domain("https://example.com")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "Not an email URL" in str(e)
+
+        # Test malformed email
+        try:
+            checker.extract_email_domain("mailto:invalidformat")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "Invalid email format" in str(e)
+
+    def test_email_links_not_treated_as_local_files(self):
+        """Test that email links are not treated as local file paths."""
+        checker = DeadLinkChecker(check_external=False, check_local=True)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            md_file = temp_path / "test.md"
+
+            md_file.write_text("""
+[Contact](mailto:contact@example.com)
+[Local file](./README.md)
+""")
+
+            links = checker.check_file(md_file)
+
+            assert len(links) == 2
+
+            # Email link should not be checked as local file
+            email_link = [link for link in links if link.url.startswith("mailto:")][0]
+            assert email_link.is_local is False
+            # Should be valid since external checking is disabled
+            assert email_link.is_valid is True
+
+            # Local file link should be checked as local
+            local_link = [link for link in links if not link.url.startswith("mailto:")][0]
+            assert local_link.is_local is True
+            # Should be invalid since README.md doesn't exist in temp dir
+            assert local_link.is_valid is False

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "pymarktools"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "gitignore-parser" },

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "pymarktools"
-version = "0.1.0a1"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "gitignore-parser" },


### PR DESCRIPTION
### Added

- Global `--version` option to the CLI, allowing users to display the current pymarktools version and exit. Implements
    Typer's recommended approach for version callbacks.
- Added this changelog
- Added `.vscode` extension recommendations

### Changed

- Adjusted Readme for more clarity
- Adjusted Project description and metadata for pypi

### Fixed

- Fixed bug where email links with `mailto:` scheme were incorrectly treated as local file paths instead of external
    URLs. Email links are now properly recognized as external and validated by checking domain existence rather than
    being flagged as missing local files.