### PR TITLE
Fix unchecked external flag behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@
 
 - Converted all docstrings to NumPy style and updated documentation linting configuration.
 - Improved `.gitignore` handling by skipping traversal into ignored directories.
-- **External URL checking behavior**: When external checking is disabled (`--no-check-external`), external URLs and images are now properly marked as `[UNCHECKED]` with yellow status instead of being incorrectly marked as valid. This provides clearer feedback about what was actually validated versus skipped.
+- **External URL checking behavior**: When external checking is disabled (`--no-check-external`), external URLs and
+  images are now properly marked as `[UNCHECKED]` with yellow status instead of being incorrectly marked as valid. This
+  provides clearer feedback about what was actually validated versus skipped.
 
 ### Fixed
 
-- Fixed misleading status reporting where external URLs/images were marked as valid when external checking was disabled. They are now correctly shown as `[UNCHECKED]` to indicate they were not validated.
+- Fixed misleading status reporting where external URLs/images were marked as valid when external checking was disabled.
+  They are now correctly shown as `[UNCHECKED]` to indicate they were not validated.
 
 ## [0.3.0] - 2025-07-16
 
@@ -54,8 +57,8 @@
 ### [0.2.0] - Fixed
 
 - Fixed bug where email links with `mailto:` scheme were incorrectly treated as local file paths instead of external
-  URLs. Email links are now properly recognized as external and validated by checking domain existence rather than
-  being flagged as missing local files.
+  URLs. Email links are now properly recognized as external and validated by checking domain existence rather than being
+  flagged as missing local files.
 
 ## [0.1.0] - 2025-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 ### Changed
 
 - Converted all docstrings to NumPy style and updated documentation linting configuration.
+- **External URL checking behavior**: When external checking is disabled (`--no-check-external`), external URLs and images are now properly marked as `[UNCHECKED]` with yellow status instead of being incorrectly marked as valid. This provides clearer feedback about what was actually validated versus skipped.
+
+### Fixed
+
+- Fixed misleading status reporting where external URLs/images were marked as valid when external checking was disabled. They are now correctly shown as `[UNCHECKED]` to indicate they were not validated.
 
 ## [0.3.0] - 2025-07-16
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ easy development and testing.
 ## Installation
 
 > [!NOTE]
-> **Python 3.12+ Required:** pymarktools requires Python 3.12+ and works best with modern terminal environments
-> that support color output.
+> **Python 3.12+ Required:** pymarktools requires Python 3.12+ and works best with modern terminal environments that
+> support color output.
 
 You can install pymarktools using several methods:
 
@@ -72,8 +72,8 @@ uvx pymarktools check --no-check-dead-images README.md
 ### Development Installation
 
 > [!TIP]
-> **Use uv for Best Experience:** For the best development experience, we recommend using `uv` for package
-> management and virtual environment handling.
+> **Use uv for Best Experience:** For the best development experience, we recommend using `uv` for package management
+> and virtual environment handling.
 
 For development or contributing:
 
@@ -93,8 +93,8 @@ This will install [pre-commit hooks](docs/pre-commit.md) that automatically run 
 type checking) before each commit, ensuring your contributions meet the project's standards.
 
 > [!IMPORTANT]
-> **Always Install Pre-commit Hooks:** Pre-commit hooks are essential for maintaining code quality. Always
-> run `uv run pre-commit install` after cloning the repository to ensure your commits meet the project's standards.
+> **Always Install Pre-commit Hooks:** Pre-commit hooks are essential for maintaining code quality. Always run
+> `uv run pre-commit install` after cloning the repository to ensure your commits meet the project's standards.
 
 ### Development Tasks
 
@@ -182,8 +182,8 @@ Local file validation supports:
 ### External URL Checking and Redirect Fixing
 
 > [!WARNING]
-> **Automatic File Modification:** When using `--fix-redirects`, the tool will modify your source files
-> automatically. Always commit your changes or create a backup before using this option.
+> **Automatic File Modification:** When using `--fix-redirects`, the tool will modify your source files automatically.
+> Always commit your changes or create a backup before using this option.
 
 Control external URL validation and redirect handling:
 
@@ -334,8 +334,8 @@ pymarktools refactor move old/path.md new/path.md --dry-run
 ### Exit Codes and CI/CD Integration
 
 > [!IMPORTANT]
-> **CI/CD Pipeline Integration:** The tool returns exit code 1 when broken links/images are found, making
-> it suitable for CI/CD pipelines. Use `--no-fail` to disable this behavior if needed.
+> **CI/CD Pipeline Integration:** The tool returns exit code 1 when broken links/images are found, making it suitable
+> for CI/CD pipelines. Use `--no-fail` to disable this behavior if needed.
 
 The tool returns appropriate exit codes for automation:
 
@@ -400,8 +400,8 @@ pymarktools check --no-check-dead-images . --include "*.md" --timeout 30 || exit
 ### pyproject.toml Support
 
 > [!NOTE]
-> **Project-wide Configuration:** Configuration via `pyproject.toml` allows you to set project-wide defaults,
-> reducing the need to specify options on every command invocation.
+> **Project-wide Configuration:** Configuration via `pyproject.toml` allows you to set project-wide defaults, reducing
+> the need to specify options on every command invocation.
 
 pymarktools supports configuration via `pyproject.toml` for project-wide settings. This allows you to define default
 behavior without specifying options on every command invocation.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ pymarktools check --no-check-dead-images docs/ --timeout 60 --check-external
 
 # Check only local files, skip external URLs
 pymarktools check --no-check-dead-images docs/ --no-check-external
+# External URLs will be reported as [UNCHECKED]
 ```
 
 Check for dead images in a markdown file or directory:
@@ -192,6 +193,7 @@ pymarktools check --no-check-dead-images <path>
 
 # Disable external URL checking
 pymarktools check --no-check-dead-images <path> --no-check-external
+# Skipped external links/images are shown as [UNCHECKED] with no status code
 
 # Automatically fix permanent redirects in source files
 pymarktools check --no-check-dead-images <path> --fix-redirects
@@ -286,7 +288,7 @@ Color coding provides instant visual feedback:
 
 - **Green (✓)**: Valid links/images
 - **Red (✗)**: Broken or invalid references
-- **Yellow**: Warnings and redirects
+- **Yellow**: Warnings, redirects, or skipped external checks
 - **Blue**: Informational messages
 
 Colors are automatically disabled when output is redirected or in non-terminal environments.

--- a/docs/pre-commit.md
+++ b/docs/pre-commit.md
@@ -1,8 +1,8 @@
 # Pre-commit Hooks
 
 > [!IMPORTANT]
-> **Essential for Code Quality:** Pre-commit hooks are essential for maintaining code quality and ensuring
-> your contributions meet the project's standards. They run the same checks as the CI pipeline.
+> **Essential for Code Quality:** Pre-commit hooks are essential for maintaining code quality and ensuring your
+> contributions meet the project's standards. They run the same checks as the CI pipeline.
 
 This project uses [pre-commit](https://pre-commit.com/) to run quality checks before each commit. The hooks ensure that
 code quality standards are maintained and match the checks run in CI.
@@ -99,8 +99,8 @@ These pre-commit hooks align with the CI checks in `.github/workflows/test.yml`:
 ## Bypassing Hooks
 
 > [!CAUTION]
-> **Use with Extreme Care:** Bypassing pre-commit hooks should be used sparingly and only when you're certain
-> the code is correct. This can lead to CI failures if code quality issues are introduced.
+> **Use with Extreme Care:** Bypassing pre-commit hooks should be used sparingly and only when you're certain the code
+> is correct. This can lead to CI failures if code quality issues are introduced.
 
 If you need to bypass pre-commit hooks temporarily:
 

--- a/docs/pyproject-config.md
+++ b/docs/pyproject-config.md
@@ -42,7 +42,7 @@ All command-line options for the `check` command can be configured in `pyproject
 | `paths`             | array of strings | Directories or files to check             |
 | `timeout`           | integer          | Request timeout in seconds                |
 | `output`            | string           | Output file for the report                |
-| `check_external`    | boolean          | Check external URLs with HTTP requests    |
+| `check_external`    | boolean          | Check external URLs with HTTP requests (false shows `UNCHECKED`) |
 | `check_local`       | boolean          | Check if local file links/images exist    |
 | `fix_redirects`     | boolean          | Update links with permanent redirects     |
 | `follow_gitignore`  | boolean          | Respect .gitignore patterns               |

--- a/docs/pyproject-config.md
+++ b/docs/pyproject-config.md
@@ -37,22 +37,22 @@ output = "link_report.txt"
 
 All command-line options for the `check` command can be configured in `pyproject.toml`:
 
-| Option              | Type             | Description                               |
-| ------------------- | ---------------- | ----------------------------------------- |
-| `paths`             | array of strings | Directories or files to check             |
-| `timeout`           | integer          | Request timeout in seconds                |
-| `output`            | string           | Output file for the report                |
+| Option              | Type             | Description                                                      |
+| ------------------- | ---------------- | ---------------------------------------------------------------- |
+| `paths`             | array of strings | Directories or files to check                                    |
+| `timeout`           | integer          | Request timeout in seconds                                       |
+| `output`            | string           | Output file for the report                                       |
 | `check_external`    | boolean          | Check external URLs with HTTP requests (false shows `UNCHECKED`) |
-| `check_local`       | boolean          | Check if local file links/images exist    |
-| `fix_redirects`     | boolean          | Update links with permanent redirects     |
-| `follow_gitignore`  | boolean          | Respect .gitignore patterns               |
-| `include_pattern`   | string           | File pattern to include                   |
-| `exclude_pattern`   | string           | File pattern to exclude                   |
-| `parallel`          | boolean          | Enable parallel processing                |
-| `fail`              | boolean          | Exit with status 1 if invalid items found |
-| `workers`           | integer          | Number of worker threads                  |
-| `check_dead_links`  | boolean          | Validate links                            |
-| `check_dead_images` | boolean          | Validate images                           |
+| `check_local`       | boolean          | Check if local file links/images exist                           |
+| `fix_redirects`     | boolean          | Update links with permanent redirects                            |
+| `follow_gitignore`  | boolean          | Respect .gitignore patterns                                      |
+| `include_pattern`   | string           | File pattern to include                                          |
+| `exclude_pattern`   | string           | File pattern to exclude                                          |
+| `parallel`          | boolean          | Enable parallel processing                                       |
+| `fail`              | boolean          | Exit with status 1 if invalid items found                        |
+| `workers`           | integer          | Number of worker threads                                         |
+| `check_dead_links`  | boolean          | Validate links                                                   |
+| `check_dead_images` | boolean          | Validate images                                                  |
 
 ## Configuration Discovery
 

--- a/docs/pyproject-config.md
+++ b/docs/pyproject-config.md
@@ -1,8 +1,8 @@
 # pyproject.toml Configuration Support
 
 > [!TIP]
-> **Consistent Team Configuration:** Using `pyproject.toml` configuration reduces the need to specify options on
-> every command invocation and ensures consistent behavior across your team.
+> **Consistent Team Configuration:** Using `pyproject.toml` configuration reduces the need to specify options on every
+> command invocation and ensures consistent behavior across your team.
 
 This document describes how to configure pymarktools using `pyproject.toml`.
 
@@ -57,8 +57,8 @@ All command-line options for the `check` command can be configured in `pyproject
 ## Configuration Discovery
 
 > [!NOTE]
-> **Automatic Discovery:** pymarktools automatically searches for `pyproject.toml` by walking up the directory
-> tree from the current working directory until it finds one.
+> **Automatic Discovery:** pymarktools automatically searches for `pyproject.toml` by walking up the directory tree from
+> the current working directory until it finds one.
 
 pymarktools automatically searches for `pyproject.toml` by walking up the directory tree from the current working
 directory until it finds one.
@@ -66,8 +66,8 @@ directory until it finds one.
 ## Priority Order
 
 > [!IMPORTANT]
-> **Predictable Configuration Behavior:** Understanding the priority order is crucial for predictable
-> behavior. Command-line arguments always take precedence over configuration file settings.
+> **Predictable Configuration Behavior:** Understanding the priority order is crucial for predictable behavior.
+> Command-line arguments always take precedence over configuration file settings.
 
 Configuration values are applied in the following order (highest priority first):
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,8 +6,8 @@
 ![](https://badgen.net/github/checks/jancschaefer/pymarktools/main)
 
 > [!IMPORTANT]
-> **Automated Release Process:** This document outlines the automated release process for pymarktools.
-> Releases are handled through GitHub Actions with PyPI's trusted publisher (OIDC) authentication for security.
+> **Automated Release Process:** This document outlines the automated release process for pymarktools. Releases are
+> handled through GitHub Actions with PyPI's trusted publisher (OIDC) authentication for security.
 
 This document outlines the release process for the pymarktools package.
 
@@ -19,8 +19,8 @@ authentication. This means no manual API tokens are required - releases are full
 ## Prerequisites
 
 > [!WARNING]
-> **Complete Preparation Required:** Ensure all prerequisites are met before starting the release process.
-> Incomplete preparation can lead to failed releases or rollbacks.
+> **Complete Preparation Required:** Ensure all prerequisites are met before starting the release process. Incomplete
+> preparation can lead to failed releases or rollbacks.
 
 - [ ] All tests are passing on the main branch
 - [ ] Version number has been updated in `pyproject.toml`
@@ -75,8 +75,8 @@ Production releases to PyPI happen when you create a GitHub release.
 ### Step 2: Create and Push a Git Tag
 
 > [!IMPORTANT]
-> **Version Matching Required:** The git tag must exactly match the version in `pyproject.toml` for the
-> automated release to work correctly.
+> **Version Matching Required:** The git tag must exactly match the version in `pyproject.toml` for the automated
+> release to work correctly.
 
 ```bash
 # Create a tag (must match the version in pyproject.toml)
@@ -184,8 +184,8 @@ If a release needs to be rolled back:
 ### Common Issues
 
 > [!TIP]
-> **Prevention is Key:** Most release issues can be prevented by ensuring all prerequisites are met and testing
-> the release process with TestPyPI first.
+> **Prevention is Key:** Most release issues can be prevented by ensuring all prerequisites are met and testing the
+> release process with TestPyPI first.
 
 1. **"Permission denied" on PyPI**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "mdformat-config>=0.2.1",
     "mdformat-gfm>=0.4.1",
     "mdformat-gfm-alerts>=2.0.0",
+    "mdformat-pyproject>=0.0.2",
     "mdformat-ruff>=0.1.3",
     "mdformat-tables>=1.0.0",
     "mdformat-toc>=0.3.0",

--- a/src/pymarktools/commands/check.py
+++ b/src/pymarktools/commands/check.py
@@ -295,7 +295,7 @@ def process_path_and_check(
             echo_if_not_quiet(f"Found {len(items)} {item_type}")
             for item in items:
                 display_item_result(item, item_type)
-                if not item.is_valid:
+                if item.is_valid is False:
                     has_invalid_items = True
         elif path.is_dir():
             results = checker.check_directory(
@@ -310,7 +310,7 @@ def process_path_and_check(
                     echo_if_not_quiet(f"\n{file_path}: Found {len(items)} {item_type}")
                 for item in items:
                     display_item_result(item, item_type)
-                    if not item.is_valid:
+                    if item.is_valid is False:
                         has_invalid_items = True
         else:
             echo_error(f"Error: {path} is not a valid file or directory")
@@ -343,7 +343,7 @@ async def process_path_and_check_async(
             echo_if_not_quiet(f"Found {len(items)} {item_type}")
             for item in items:
                 display_item_result(item, item_type)
-                if not item.is_valid:
+                if item.is_valid is False:
                     has_invalid_items = True
         elif path.is_dir():
             # Progress callback for real-time updates
@@ -359,7 +359,7 @@ async def process_path_and_check_async(
                 # Display results for this file immediately
                 for item in items:
                     display_item_result(item, item_type)
-                    if not item.is_valid:
+                    if item.is_valid is False:
                         has_invalid_items_ref[0] = True
 
             # Run async directory check with progress reporting
@@ -383,7 +383,7 @@ async def process_path_and_check_async(
                         echo_if_not_quiet(f"\n{file_path}: Found {len(items)} {item_type}")
                     for item in items:
                         display_item_result(item, item_type)
-                        if not item.is_valid:
+                        if item.is_valid is False:
                             has_invalid_items = True
         else:
             echo_error(f"Error: {path} is not a valid file or directory")
@@ -398,15 +398,18 @@ async def process_path_and_check_async(
 def display_item_result(item: Any, item_type: str) -> None:
     """Display the result for a single link or image item."""
     # Build status string with color coding
-    if item.is_valid:
+    if item.is_valid is True:
         status = "VALID"
         status_color = typer.colors.GREEN
-    else:
+    elif item.is_valid is False:
         status = "INVALID"
         status_color = typer.colors.RED
+    else:
+        status = "UNCHECKED"
+        status_color = typer.colors.YELLOW
 
     # Add status code if available
-    if item.status_code:
+    if item.status_code is not None:
         status += f" {item.status_code}"
 
     # Add update indicator

--- a/src/pymarktools/core/image_checker.py
+++ b/src/pymarktools/core/image_checker.py
@@ -169,10 +169,10 @@ class DeadImageChecker(AsyncChecker[ImageInfo]):
                     image.updated = True
                     updated = True
         else:
-            # External images but not checking - mark as valid
+            # External images but not checking - mark as unchecked
             for image in external_images:
-                image.is_valid = True
-                image.status_code = 200
+                image.is_valid = None
+                image.status_code = None
 
         # Process local images sequentially (file I/O is typically fast and doesn't benefit much from parallelization)
         for image in local_images:

--- a/src/pymarktools/core/link_checker.py
+++ b/src/pymarktools/core/link_checker.py
@@ -250,10 +250,10 @@ class DeadLinkChecker(AsyncChecker[LinkInfo]):
                     link.updated = True
                     updated = True
         else:
-            # External links but not checking - mark as valid
+            # External links but not checking - mark as unchecked
             for link in external_links:
-                link.is_valid = True
-                link.status_code = 000
+                link.is_valid = None
+                link.status_code = None
 
         # Process local links sequentially (file I/O is typically fast and doesn't benefit much from parallelization)
         for link in local_links:

--- a/tests/test_core/test_email_links.py
+++ b/tests/test_core/test_email_links.py
@@ -142,8 +142,8 @@ Regular link: [website](https://example.com)
             # Email link should not be checked as local file
             email_link = [link for link in links if link.url.startswith("mailto:")][0]
             assert email_link.is_local is False
-            # Should be valid since external checking is disabled
-            assert email_link.is_valid is True
+            # External checking disabled -> mark as unchecked
+            assert email_link.is_valid is None
 
             # Local file link should be checked as local
             local_link = [link for link in links if not link.url.startswith("mailto:")][0]

--- a/tests/test_core/test_image_checker.py
+++ b/tests/test_core/test_image_checker.py
@@ -102,11 +102,10 @@ Line 3 with ![second image](https://test.com/2.png)"""
 
         images = checker.check_file(temp_markdown_file)
 
-        # External images should be marked as valid (not checked)
-        # Local images will fail since the files don't exist, but that's expected
+        # External images should be marked as unchecked
         external_images = [image for image in images if image.is_local is False]
-        assert all(image.is_valid for image in external_images)
-        assert all(image.status_code == 200 for image in external_images)
+        assert all(image.is_valid is None for image in external_images)
+        assert all(image.status_code is None for image in external_images)
 
     def test_init_with_custom_params(self):
         checker = DeadImageChecker(
@@ -185,9 +184,9 @@ Line 3 with ![second image](https://test.com/2.png)"""
 
             assert len(images) == 3
 
-            # External image should be valid (not checked)
+            # External image should be marked as unchecked
             external_image = [image for image in images if image.url == "https://example.com/image.jpg"][0]
-            assert external_image.is_valid is True
+            assert external_image.is_valid is None
             assert external_image.is_local is False
 
             # Existing local file should be valid
@@ -217,8 +216,12 @@ Line 3 with ![second image](https://test.com/2.png)"""
 
             images = checker.check_file(md_file)
 
-            # All images should be marked as valid when checking is disabled
-            assert all(image.is_valid for image in images)
+            # External images remain unchecked when both checks are disabled
+            external_images = [img for img in images if img.is_local is False]
+            assert all(img.is_valid is None for img in external_images)
+            # Local images are considered valid when local checking is disabled
+            local_images = [img for img in images if img.is_local]
+            assert all(img.is_valid for img in local_images)
 
             # Local images should be marked as local
             local_image = [image for image in images if image.url == "missing.png"][0]

--- a/tests/test_core/test_link_checker.py
+++ b/tests/test_core/test_link_checker.py
@@ -102,12 +102,11 @@ Line 3 with [another link](https://test.com)"""
 
         links = checker.check_file(temp_markdown_file)
 
-        # External links should be marked as valid (not checked)
-        # Local links will fail since the files don't exist, but that's expected
+        # External links should be marked as unchecked when skipping external validation
         external_links = [link for link in links if link.is_local is False]
-        assert all(link.is_valid for link in external_links)
-        # When external checking is disabled, status_code should be 000 (not checked)
-        assert all(link.status_code == 000 for link in external_links)
+        assert all(link.is_valid is None for link in external_links)
+        # When external checking is disabled, no status code should be recorded
+        assert all(link.status_code is None for link in external_links)
 
     def test_init_with_custom_params(self):
         checker = DeadLinkChecker(
@@ -222,9 +221,9 @@ Line 3 with [another link](https://test.com)"""
 
             assert len(links) == 3
 
-            # External link should be valid (not checked)
+            # External link should be marked as unchecked
             external_link = [link for link in links if link.url == "https://example.com"][0]
-            assert external_link.is_valid is True
+            assert external_link.is_valid is None
             assert external_link.is_local is False
 
             # Existing local file should be valid
@@ -254,8 +253,12 @@ Line 3 with [another link](https://test.com)"""
 
             links = checker.check_file(md_file)
 
-            # All links should be marked as valid when checking is disabled
-            assert all(link.is_valid for link in links)
+            # External links remain unchecked when both checks are disabled
+            external_links = [link for link in links if link.is_local is False]
+            assert all(link.is_valid is None for link in external_links)
+            # Local links are treated as valid when local checking is disabled
+            local_links = [link for link in links if link.is_local]
+            assert all(link.is_valid for link in local_links)
 
             # Local links should be marked as local
             local_link = [link for link in links if link.url == "missing.md"][0]

--- a/uv.lock
+++ b/uv.lock
@@ -261,6 +261,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat-pyproject"
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/b0/6c7342afcb5518891f3c908f9e9f73fc399b727fe5b8133b31c8d468eae6/mdformat_pyproject-0.0.2.tar.gz", hash = "sha256:1638c4be0d239f49eea72089aafd06dc4ec603068ccc4868f91f0958b15b82c8", size = 5550 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/d7/0598e8de54d439ee7deda6bcba7816b36aaf28c26542ff9a0510cc29c079/mdformat_pyproject-0.0.2-py3-none-any.whl", hash = "sha256:e0791a335e53264d5589be353c519e230ac555b64fa076005bc64ca037717710", size = 4761 },
+]
+
+[[package]]
 name = "mdformat-ruff"
 version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -439,6 +451,7 @@ dev = [
     { name = "mdformat-config" },
     { name = "mdformat-gfm" },
     { name = "mdformat-gfm-alerts" },
+    { name = "mdformat-pyproject" },
     { name = "mdformat-ruff" },
     { name = "mdformat-tables" },
     { name = "mdformat-toc" },
@@ -466,6 +479,7 @@ dev = [
     { name = "mdformat-config", specifier = ">=0.2.1" },
     { name = "mdformat-gfm", specifier = ">=0.4.1" },
     { name = "mdformat-gfm-alerts", specifier = ">=2.0.0" },
+    { name = "mdformat-pyproject", specifier = ">=0.0.2" },
     { name = "mdformat-ruff", specifier = ">=0.1.3" },
     { name = "mdformat-tables", specifier = ">=1.0.0" },
     { name = "mdformat-toc", specifier = ">=0.3.0" },


### PR DESCRIPTION
This pull request introduces changes to enhance the handling and reporting of unchecked external links and images in the `pymarktools` project. The updates include modifications to the command-line tool, configuration, core logic, and test cases to ensure consistent behavior when external checks are disabled.

### Updates to Documentation and User Feedback:
* Updated `README.md` to clarify that skipped external links/images are marked as `[UNCHECKED]` and included this in the color-coding legend. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R147) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R196) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L289-R291)
* Updated `docs/pyproject-config.md` to reflect that disabling external checks (`check_external=false`) results in external items being marked as `[UNCHECKED]`.

### Core Logic Enhancements:
* Modified `src/pymarktools/commands/check.py` to explicitly check for `item.is_valid is False` instead of relying on implicit falsy evaluation, improving code clarity and consistency. [[1]](diffhunk://#diff-9679ba79c98d8ac0bdd6c6d652af53f8c9fe34af5e064b59e74b570eca179b06L298-R298) [[2]](diffhunk://#diff-9679ba79c98d8ac0bdd6c6d652af53f8c9fe34af5e064b59e74b570eca179b06L313-R313) [[3]](diffhunk://#diff-9679ba79c98d8ac0bdd6c6d652af53f8c9fe34af5e064b59e74b570eca179b06L346-R346) [[4]](diffhunk://#diff-9679ba79c98d8ac0bdd6c6d652af53f8c9fe34af5e064b59e74b570eca179b06L362-R362) [[5]](diffhunk://#diff-9679ba79c98d8ac0bdd6c6d652af53f8c9fe34af5e064b59e74b570eca179b06L386-R386)
* Updated `display_item_result` to handle `None` as the `is_valid` value for unchecked items, displaying them as `[UNCHECKED]` with a yellow status.
* Changed `check_file_async` in `image_checker.py` and `link_checker.py` to set `is_valid=None` and `status_code=None` for unchecked external items, ensuring they are not treated as valid by default. [[1]](diffhunk://#diff-0814267c26096bf00a098f3fc211cb5a7bd1544d85e052cd37dc2c7598e88355L172-R175) [[2]](diffhunk://#diff-d9a66d1bd51ea1d6db83c26bc67a56e4fc41e3c41469dd515c8e6b9c7218e091L253-R256)

### Test Case Adjustments:
* Updated test cases across `test_image_checker.py`, `test_link_checker.py`, and `test_email_links.py` to validate the new behavior for unchecked external links and images, ensuring they are marked as `is_valid=None` and `status_code=None`. [[1]](diffhunk://#diff-a309eed26c4985e577221e3b276995e9ef05e81faefaf772a917e1d5fd926863L145-R146) [[2]](diffhunk://#diff-49bbb3d816bdc9ec2c50494b7a45cf67e74c98baf326546120ddb3ece0e1bd5bL105-R108) [[3]](diffhunk://#diff-49bbb3d816bdc9ec2c50494b7a45cf67e74c98baf326546120ddb3ece0e1bd5bL188-R189) [[4]](diffhunk://#diff-49bbb3d816bdc9ec2c50494b7a45cf67e74c98baf326546120ddb3ece0e1bd5bL220-R224) [[5]](diffhunk://#diff-c28a4357e30d70eb23bc509314a2d187af5eec5c3ac0ef04142fa81a43a839f0L105-R109) [[6]](diffhunk://#diff-c28a4357e30d70eb23bc509314a2d187af5eec5c3ac0ef04142fa81a43a839f0L225-R226) [[7]](diffhunk://#diff-c28a4357e30d70eb23bc509314a2d187af5eec5c3ac0ef04142fa81a43a839f0L257-R261)## Summary
- mark external links/images as `UNCHECKED` when `--no-check-external`
- don't treat unchecked items as invalid
- show yellow status for unchecked items
- document new behaviour for `--check-external/--no-check-external`
- update tests for new semantics
