### PR TITLE
Improve gitignore traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - Converted all docstrings to NumPy style and updated documentation linting configuration.
+- Improved `.gitignore` handling by skipping traversal into ignored directories.
 
 ## [0.3.0] - 2025-07-16
 

--- a/src/pymarktools/core/async_checker.py
+++ b/src/pymarktools/core/async_checker.py
@@ -85,6 +85,10 @@ class AsyncChecker[T]:
         async def process_directory_level(dir_path: Path) -> list[Path]:
             """Process a single directory level and return matching files."""
             try:
+                # Skip processing if the directory itself is ignored
+                if self.follow_gitignore and gitignore_matcher and is_path_ignored(dir_path, gitignore_matcher):
+                    return []
+
                 files: list[Path] = []
                 subdirs: list[Path] = []
 
@@ -93,6 +97,8 @@ class AsyncChecker[T]:
                     if item.is_file():
                         files.append(item)
                     elif item.is_dir():
+                        if self.follow_gitignore and gitignore_matcher and is_path_ignored(item, gitignore_matcher):
+                            continue
                         subdirs.append(item)
 
                 # Process files in current directory

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -509,11 +509,14 @@ Thumbs.db
         # Create various files and directories
         (temp_path / "README.md").write_text("# Project\n\n[Link](https://example.com)")
 
-        # Create ignored directories
+        # Create ignored directories with nested content
         for ignored_dir in ["node_modules", ".venv", "dist", "__pycache__", ".vscode"]:
             dir_path = temp_path / ignored_dir
             dir_path.mkdir()
             (dir_path / "file.md").write_text("# Ignored\n\n[Link](https://example.com)")
+            nested_dir = dir_path / "lib"
+            nested_dir.mkdir()
+            (nested_dir / "nested.md").write_text("# Nested\n\n[Link](https://example.com)")
 
         # Create ignored files
         (temp_path / ".DS_Store").write_text("binary file")

--- a/tests/test_core/test_gitignore_discovery.py
+++ b/tests/test_core/test_gitignore_discovery.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from pymarktools.core.async_checker import AsyncChecker
+
+
+def test_discover_files_skips_ignored_root(tmp_path: Path) -> None:
+    """Ensure discover_files_async returns no files when the given path is ignored."""
+    (tmp_path / ".gitignore").write_text(".venv\n")
+    # Simulate a git repository so parent .gitignore is respected
+    (tmp_path / ".git").mkdir()
+    ignored = tmp_path / ".venv"
+    ignored.mkdir()
+    (ignored / "file.md").write_text("content")
+
+    checker = AsyncChecker()
+    result = checker.run_async_with_fallback(checker.discover_files_async, ignored)
+    assert result == []


### PR DESCRIPTION
Improved `.gitignore` handling by skipping traversal into ignored directories.

## Summary
- avoid exploring directories if they are already ignored
- include nested ignored directories in CLI tests
- document gitignore performance improvement
- handle ignored directories passed as the root path
- test skipping of ignored root paths