### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+## [0.4.0] - 2026-08-12
+
 ### Added
 
 - Rust-native Markdown parsing, file discovery, validation, configuration loading, and reference rewriting, packaged

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "pymarktools-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "globset",
  "ignore",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "pymarktools-py"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "pymarktools-core",
  "pyo3",

--- a/crates/pymarktools-core/Cargo.toml
+++ b/crates/pymarktools-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pymarktools-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 

--- a/crates/pymarktools-py/Cargo.toml
+++ b/crates/pymarktools-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pymarktools-py"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pymarktools"
-version = "0.3.0"
+version = "0.4.0"
 description = "A set of markdown utilities for Python, designed to simplify the manipulation and parsing of markdown text. This project leverages Typer for a user-friendly command line interface and is built with a solid codebase structure to facilitate easy development and testing."
 authors = [
     {name = 'Jan Schäfer', email = 'jan@schae.fr'},

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "pymarktools"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## Summary

- release the Rust-native core as pymarktools 0.4.0
- align Python and Rust package metadata and lockfiles
- promote the validated migration notes in CHANGELOG.md

## Verification

- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- uv run ruff check src/pymarktools tests
- uv run ruff format --check src/pymarktools tests
- uv run ty check
- uv run pytest --cov=src/pymarktools --cov-fail-under=80 (143 passed, 88.87%)
- built cp312-abi3 wheel; metadata confirms version 0.4.0 and Python >=3.12