### PR TITLE
fix: release correct package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,4 +137,5 @@ jobs:
         run: >-
           gh release upload
           '${{ github.ref_name }}' dist/**
+          --clobber
           --repo '${{ github.repository }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [unreleased]
 
+## [0.4.1] - 2026-08-12
+
+### Fixed
+
+- Public package and CLI version reporting now use the installed distribution metadata.
+- GitHub release distribution uploads now safely replace existing assets when a release workflow is rerun.
+
 ## [0.4.0] - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "pymarktools-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "globset",
  "ignore",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "pymarktools-py"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pymarktools-core",
  "pyo3",

--- a/crates/pymarktools-core/Cargo.toml
+++ b/crates/pymarktools-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pymarktools-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.85"
 

--- a/crates/pymarktools-py/Cargo.toml
+++ b/crates/pymarktools-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pymarktools-py"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.85"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pymarktools"
-version = "0.4.0"
+version = "0.4.1"
 description = "A set of markdown utilities for Python, designed to simplify the manipulation and parsing of markdown text. This project leverages Typer for a user-friendly command line interface and is built with a solid codebase structure to facilitate easy development and testing."
 authors = [
     {name = 'Jan Schäfer', email = 'jan@schae.fr'},

--- a/src/pymarktools/__init__.py
+++ b/src/pymarktools/__init__.py
@@ -1,11 +1,12 @@
 """pymarktools - A set of markdown utilities for Python."""
 
 import logging
+from importlib.metadata import version
 
 from .core.markdown import DeadImageChecker, DeadLinkChecker, ImageInfo, LinkInfo
 from .core.refactor import FileReference, FileReferenceManager
 
-__version__ = "0.3.0"
+__version__ = version("pymarktools")
 __all__ = [
     "DeadLinkChecker",
     "DeadImageChecker",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,9 +99,18 @@ def test_check_dead_images_help(runner):
 def test_cli_version(runner):
     result = runner.invoke(app, ["--version"])
     assert result.exit_code == 0
+
     from pymarktools import __version__
 
     assert __version__ in result.output
+
+
+def test_package_version_matches_installed_metadata():
+    from importlib.metadata import version
+
+    from pymarktools import __version__
+
+    assert __version__ == version("pymarktools")
 
 
 def test_verbose_flag(runner, temp_valid_markdown_file):

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 
 [[package]]
 name = "pymarktools"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## Summary

- make the public package and CLI report installed distribution metadata
- release 0.4.1 because PyPI cannot replace the already-uploaded 0.4.0 artifacts
- make GitHub release asset uploads idempotent for workflow reruns

## Verification

- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- uv run ruff check src/pymarktools tests
- uv run ruff format --check src/pymarktools tests
- uv run ty check
- uv run pytest --cov=src/pymarktools --cov-fail-under=80 (144 passed, 88.89%)
- isolated 0.4.1 ABI3 wheel: pymarktools --version outputs 0.4.1